### PR TITLE
Webservice cdn changes

### DIFF
--- a/PhotoSharingApp/PhotoSharingApp.AppService.Shared/Models/DocumentDB/PhotoDocument.cs
+++ b/PhotoSharingApp/PhotoSharingApp.AppService.Shared/Models/DocumentDB/PhotoDocument.cs
@@ -67,8 +67,8 @@ namespace PhotoSharingApp.AppService.Shared.Models.DocumentDB
         /// <summary>
         /// The cropped image url. Cropped via Cognitive Services. This is not guaranteed.
         /// </summary>
-        [JsonProperty(PropertyName = "CroppedImageUrl")]
-        public string CroppedImageUrl { get; set; }
+        [JsonProperty(PropertyName = "CroppedUrl")]
+        public string CroppedUrl { get; set; }
 
         /// <summary>
         /// The photo description.

--- a/PhotoSharingApp/PhotoSharingApp.AppService.Shared/Models/Settings.cs
+++ b/PhotoSharingApp/PhotoSharingApp.AppService.Shared/Models/Settings.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PhotoSharingApp.AppService.Shared.Models
+{
+    static class Settings
+    {
+        private static string imageBaseUrl = null;
+        public static string ImageBaseUrl {
+            get
+            {
+                if (imageBaseUrl == null)
+                    imageBaseUrl = ConfigurationManager.AppSettings["ImageBaseUrl"];
+
+                return imageBaseUrl;
+            }
+            set
+            {
+                imageBaseUrl = value;
+            }
+        }
+    }
+}

--- a/PhotoSharingApp/PhotoSharingApp.AppService.Shared/PhotoSharingApp.AppService.Shared.csproj
+++ b/PhotoSharingApp/PhotoSharingApp.AppService.Shared/PhotoSharingApp.AppService.Shared.csproj
@@ -80,6 +80,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -152,6 +153,7 @@
     <Compile Include="Models\DocumentDB\UserDocument.cs" />
     <Compile Include="Models\DocumentDB\IapPurchaseDocument.cs" />
     <Compile Include="Models\DocumentDB\GoldTransactionDocument.cs" />
+    <Compile Include="Models\Settings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repositories\CachedRepository.cs" />
     <Compile Include="Repositories\DocumentDbRepository.cs" />

--- a/PhotoSharingApp/PhotoSharingApp.AppService.Shared/Repositories/DocumentDbRepository.cs
+++ b/PhotoSharingApp/PhotoSharingApp.AppService.Shared/Repositories/DocumentDbRepository.cs
@@ -210,6 +210,8 @@ namespace PhotoSharingApp.AppService.Shared.Repositories
                 await GetAllUserDocumentsFromIdList(photoDocuments.Select(p => p.UserId)
                     .Concat(photoDocuments.SelectMany(p => p.Annotations).Select(a => a.From)).ToList());
 
+            ConvertImageUrlsToFullyQualified(userDocumentsForPhotosAndAnnotations);
+
             // Pass in the collection of users so ToContract can set the proper user objects for PhotoContract and the AnnotationContracts.
             return
                 photoDocuments.Select(photoDocument => photoDocument.ToContract(userDocumentsForPhotosAndAnnotations))
@@ -847,6 +849,8 @@ namespace PhotoSharingApp.AppService.Shared.Repositories
                 throw new DataLayerException(DataLayerError.NotFound, $"No user with id {userId} found");
             }
 
+            ConvertImageUrlsToFullyQualified(user);
+
             return user;
         }
 
@@ -1167,6 +1171,8 @@ namespace PhotoSharingApp.AppService.Shared.Repositories
 
         private async Task<UserDocument> ReplaceUserDocument(UserDocument userDocument)
         {
+            ConvertImageUrlsToPathOnly(userDocument);
+
             var existingUser = GetUserDocumentByRegistrationReference(userDocument.RegistrationReference);
 
             // First time profile pic update awards user some gold (value found in environment definitions)
@@ -1373,6 +1379,52 @@ namespace PhotoSharingApp.AppService.Shared.Repositories
         }
 
         /// <summary>
+        /// Method to effectively strip the domain portion of the image urls so they are paths only.
+        /// </summary>
+        /// <param name="user">A UserDocument object.</param>
+        private void ConvertImageUrlsToPathOnly(UserDocument user)
+        {
+            if (!user.ProfilePhotoUrl?.StartsWith("/", StringComparison.OrdinalIgnoreCase) ?? false)
+                user.ProfilePhotoUrl = new Uri(user.ProfilePhotoUrl).PathAndQuery;
+        }
+
+        /// <summary>
+        /// Method to effectively strip the domain portion of the image urls so they are paths only.
+        /// </summary>
+        /// <param name="user">A UserContract object.</param>
+        private void ConvertImageUrlsToPathOnly(UserContract user)
+        {
+            if (!user.ProfilePhotoUrl?.StartsWith("/", StringComparison.OrdinalIgnoreCase) ?? false)
+                user.ProfilePhotoUrl = new Uri(user.ProfilePhotoUrl).PathAndQuery;
+        }
+
+        /// <summary>
+        /// Method to effectively strip the domain portion of the image urls so they are paths only.
+        /// </summary>
+        /// <param name="users">A List of UserContract objects.</param>
+        private void ConvertImageUrlsToPathOnly(IList<UserContract> users)
+        {
+            foreach (var user in users)
+            {
+                if (!user.ProfilePhotoUrl?.StartsWith("/", StringComparison.OrdinalIgnoreCase) ?? false)
+                    user.ProfilePhotoUrl = new Uri(user.ProfilePhotoUrl).PathAndQuery;
+            }
+        }
+
+        /// <summary>
+        /// Method to effectively strip the domain portion of the image urls so they are paths only.
+        /// </summary>
+        /// <param name="users">A List of UserContract objects.</param>
+        private void ConvertImageUrlsToPathOnly(IList<UserDocument> users)
+        {
+            foreach (var user in users)
+            {
+                if (!user.ProfilePhotoUrl?.StartsWith("/", StringComparison.OrdinalIgnoreCase) ?? false)
+                    user.ProfilePhotoUrl = new Uri(user.ProfilePhotoUrl).PathAndQuery;
+            }
+        }
+
+        /// <summary>
         /// Method to effectively add  strip the domain portion of the image urls so they are paths only.
         /// </summary>
         /// <param name="photo">A PhotoDocument object.</param>
@@ -1451,6 +1503,52 @@ namespace PhotoSharingApp.AppService.Shared.Repositories
 
                 if (photo.ThumbnailUrl?.StartsWith("/", StringComparison.OrdinalIgnoreCase) ?? false)
                     photo.ThumbnailUrl = $"{Settings.ImageBaseUrl}{photo.ThumbnailUrl}";
+            }
+        }
+        
+        /// <summary>
+        /// Method to effectively add  strip the domain portion of the image urls so they are paths only.
+        /// </summary>
+        /// <param name="user">A UserDocument object.</param>
+        private void ConvertImageUrlsToFullyQualified(UserContract user)
+        {
+            if (user.ProfilePhotoUrl?.StartsWith("/", StringComparison.OrdinalIgnoreCase) ?? false)
+                user.ProfilePhotoUrl = $"{Settings.ImageBaseUrl}{user.ProfilePhotoUrl}";
+        }
+
+        /// <summary>
+        /// Method to effectively add  strip the domain portion of the image urls so they are paths only.
+        /// </summary>
+        /// <param name="user">A UserDocument object.</param>
+        private void ConvertImageUrlsToFullyQualified(UserDocument user)
+        {
+            if (user.ProfilePhotoUrl?.StartsWith("/", StringComparison.OrdinalIgnoreCase) ?? false)
+                user.ProfilePhotoUrl = $"{Settings.ImageBaseUrl}{user.ProfilePhotoUrl}";
+        }
+
+        /// <summary>
+        /// Method to effectively add  strip the domain portion of the image urls so they are paths only.
+        /// </summary>
+        /// <param name="users">A List of UserContract objects</param>
+        private void ConvertImageUrlsToFullyQualified(IList<UserContract> users)
+        {
+            foreach (var user in users)
+            {
+                if (user.ProfilePhotoUrl?.StartsWith("/", StringComparison.OrdinalIgnoreCase) ?? false)
+                    user.ProfilePhotoUrl = $"{Settings.ImageBaseUrl}{user.ProfilePhotoUrl}";
+            }
+        }
+
+        /// <summary>
+        /// Method to effectively add  strip the domain portion of the image urls so they are paths only.
+        /// </summary>
+        /// <param name="users">A List of UserDocument objects</param>
+        private void ConvertImageUrlsToFullyQualified(IList<UserDocument> users)
+        {
+            foreach (var user in users)
+            {
+                if (user.ProfilePhotoUrl?.StartsWith("/", StringComparison.OrdinalIgnoreCase) ?? false)
+                    user.ProfilePhotoUrl = $"{Settings.ImageBaseUrl}{user.ProfilePhotoUrl}";
             }
         }
     }

--- a/PhotoSharingApp/PhotoSharingApp.AppService/Controllers/CategoryController.cs
+++ b/PhotoSharingApp/PhotoSharingApp.AppService/Controllers/CategoryController.cs
@@ -69,7 +69,7 @@ namespace PhotoSharingApp.AppService.Controllers
         /// <param name="continuationToken">continuation token to page through the result.</param>
         /// <returns>Paged list of photo contract.</returns>
         [Route("api/category/{id}")]
-        public async Task<PagedResponse<PhotoContract>> GetAsync(string id, [FromUri] string continuationToken)
+        public async Task<PagedResponse<PhotoContract>> GetAsync(string id, [FromUri] string continuationToken = null)
         {
             try
             {

--- a/PhotoSharingApp/PhotoSharingApp.AppService/Web.config
+++ b/PhotoSharingApp/PhotoSharingApp.AppService/Web.config
@@ -22,6 +22,7 @@
     <add key="NewPhotoAward" value="1" />
     <!-- Service Bus specific app setings for messaging connections -->
     <add key="PreserveLoginUrl" value="true" />
+    <add key="ImageBaseUrl" value="https://snapgold.azureedge.net" />
   </appSettings>
   <system.web>
     <httpRuntime targetFramework="4.5" />

--- a/PhotoSharingApp/PhotoSharingApp.Frontend.Portable/Models/Photo.cs
+++ b/PhotoSharingApp/PhotoSharingApp.Frontend.Portable/Models/Photo.cs
@@ -137,17 +137,7 @@ namespace PhotoSharingApp.Frontend.Portable.Models
         /// <summary>
         /// Gets or sets the high resolution image URL.
         /// </summary>
-        public string HighResolutionUrl
-        {
-            get
-            {
-                return _highResolutionUrl.Replace("snapgolddemostorage.blob.core.windows.net", "snapgold.azureedge.net");
-            }
-            set
-            {
-                _highResolutionUrl = value;
-            }
-        }
+        public string HighResolutionUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the unique identifier.
@@ -163,10 +153,10 @@ namespace PhotoSharingApp.Frontend.Portable.Models
             {
                 //if (AppEnvironment.Instance.IsMobileDeviceFamily)
                 //{
-                //    return StandardUrl;
+                return StandardUrl;
                 //}
 
-                return HighResolutionUrl;
+                //return HighResolutionUrl;
             }
         }
 
@@ -201,17 +191,7 @@ namespace PhotoSharingApp.Frontend.Portable.Models
         /// <summary>
         /// Gets or sets the standard image URL.
         /// </summary>
-        public string StandardUrl
-        {
-            get
-            {
-                return _standardUrl.Replace("snapgolddemostorage.blob.core.windows.net", "snapgold.azureedge.net");
-            }
-            set
-            {
-                _standardUrl = value;
-            }
-        }
+        public string StandardUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the photo status.
@@ -221,17 +201,7 @@ namespace PhotoSharingApp.Frontend.Portable.Models
         /// <summary>
         /// Gets or sets the thumbnail image URL.
         /// </summary>
-        public string ThumbnailUrl
-        {
-            get
-            {
-                return _thumbnailurl.Replace("snapgolddemostorage.blob.core.windows.net", "snapgold.azureedge.net");
-            }
-            set
-            {
-                _thumbnailurl = value;
-            }
-        }
+        public string ThumbnailUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the user.

--- a/PhotoSharingApp/PhotoSharingApp.Frontend.Portable/Models/PhotoThumbnail.cs
+++ b/PhotoSharingApp/PhotoSharingApp.Frontend.Portable/Models/PhotoThumbnail.cs
@@ -34,16 +34,6 @@ namespace PhotoSharingApp.Frontend.Portable.Models
         /// <summary>
         /// Gets or sets the image URL.
         /// </summary>
-        public string ImageUrl
-        {
-            get
-            {
-                return _imageUrl.Replace("snapgolddemostorage.blob.core.windows.net", "snapgold.azureedge.net");
-            }
-            set
-            {
-                _imageUrl = value;
-            }
-        }
+        public string ImageUrl { get; set; }
     }
 }

--- a/PhotoSharingApp/PhotoSharingApp.Functions/GenerateKeywords.cs
+++ b/PhotoSharingApp/PhotoSharingApp.Functions/GenerateKeywords.cs
@@ -30,6 +30,7 @@ namespace PhotoSharingApp.Functions
         private static string EmotionApiSubscriptionKey = ConfigurationManager.AppSettings["EmotionApiSubscriptionKey"];
         private static string VisionApiRequestUrlAnalyze = ConfigurationManager.AppSettings["VisionApiRequestUrlAnalyze"];
         private static string EmotionApiRequestUrlRecognize = ConfigurationManager.AppSettings["EmotionApiRequestUrlRecognize"];
+        private static string ImageUrlBase = ConfigurationManager.AppSettings["ImageUrlBase"];
 
 
         [FunctionName("GenerateKeywords")]
@@ -66,7 +67,7 @@ namespace PhotoSharingApp.Functions
                     string caption = null;
 
                     // Let's use Cog Services to get some keywords
-                    var imageUrl = (string)document["StandardUrl"];
+                    var imageUrl = $"{ImageUrlBase}{(string)document["StandardUrl"]}";
 
                     var visionResponse = visionHttpClient.PostAsync(VisionApiRequestUrlAnalyze, new StringContent($"{{\"url\":\"{imageUrl}\"}}", Encoding.UTF8, "application/json")).Result;
                     var visionJson = visionResponse.Content.ReadAsStringAsync().Result;

--- a/PhotoSharingApp/PhotoSharingApp.Functions/local.settings.json
+++ b/PhotoSharingApp/PhotoSharingApp.Functions/local.settings.json
@@ -10,6 +10,7 @@
     "VisionApiSubscriptionKey": "13b4c92af6bc4e80a3337499f47de2fa",
     "EmotionApiSubscriptionKey": "55fe1bd0eb2549039dd9301911b50d32",
     "VisionApiRequestUrlAnalyze": "https://westeurope.api.cognitive.microsoft.com/vision/v1.0/analyze?visualFeatures=Categories,Tags,Description&language=en",
-    "EmotionApiRequestUrlRecognize": "https://westus.api.cognitive.microsoft.com/emotion/v1.0/recognize"
+    "EmotionApiRequestUrlRecognize": "https://westus.api.cognitive.microsoft.com/emotion/v1.0/recognize",
+    "ImageUrlBase": "https://snapgolddemostorage.blob.core.windows.net"
   }
 }


### PR DESCRIPTION
AppService (api app) now manages image urls to be stored with path only - strips domain element. When photo doc is retrieved from db urls (paths) are changed to fully qualified using imagebaseurl defined in settings class (from web.config).
